### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@ cd tapyrusjs-react-example
 2. Start tapyrus node and esplora
 
 ```
-docker compose up -d tapyrus esplora
+docker compose up -d
+```
+
+Then, generates first block to start to sync esplora to tapyrusd.
+
+```
+docker-compose exec tapyrus tapyrus-cli -conf=/etc/tapyrus/tapyrus.conf generatetoaddress 1 \
+  $(docker-compose exec tapyrus tapyrus-cli -conf=/etc/tapyrus/tapyrus.conf getnewaddress) \
+  cUJN5RVzYWFoeY8rUztd47jzXCu1p57Ay8V7pqCzsBD3PEXN7Dd4
 ```
 
 3. Build application


### PR DESCRIPTION
Add generate block step before starts Electrs HTTP server

If it doesn't generate a block, esplora doesn't make it ready to accept connections. Esplora waits to done the initial block download on tapyrusd.